### PR TITLE
[FE] 선수 명단 페이지 구성

### DIFF
--- a/FE/src/components/PlayerListPage/PlayerInfoList/PlayerInfoList.tsx
+++ b/FE/src/components/PlayerListPage/PlayerInfoList/PlayerInfoList.tsx
@@ -2,15 +2,72 @@ import React from "react";
 import styled from "styled-components";
 import { IPlayerList, IPlayer } from "@/models/playerList";
 
-const Wrapper = styled.table``;
+const Wrapper = styled.table`
+  width: 50%;
+  height: 100%;
+  &:first-child {
+    border-right: solid 2px #fff;
+  }
+`;
 
-const TeamTitle = styled.div``;
+const TeamTitle = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-weight: 600;
+  font-size: 2rem;
+  margin: 0 10px;
+  padding: 10px 0;
+  border-bottom: solid 2px #fff;
+  span {
+    color: red;
+    font-size: 1rem;
+    margin-left: 10px;
+  }
+`;
 
-const Table = styled.div``;
+const Table = styled.div`
+  display: flex;
+  justify-content: start;
+  align-items: center;
+  flex-direction: column;
+  width: 100%;
+  height: 87%;
+`;
 
-const THeader = styled.thead``;
+const THeader = styled.thead`
+  width: 95.8%;
+  font-size: 1.2rem;
+  color: #939393b5;
+  margin: 0 5px;
+  padding: 5px 0;
+  border-bottom: solid 2px #939393b5;
+  tr {
+    display: flex;
+    justify-content: space-around;
+  }
+`;
 
-const TBody = styled.tbody``;
+const TBody = styled.tbody`
+  width: 95.8%;
+  display: flex;
+  height: 80%;
+  flex-wrap: wrap;
+  align-items: inherit;
+  padding: 5px 0;
+  tr {
+    display: flex;
+    width: 100%;
+    justify-content: space-around;
+    padding: 4px 0;
+    font-size: 1.2rem;
+    border-bottom: solid 1px #9393935c;
+  }
+  td {
+    width: 20%;
+    text-align: center;
+  }
+`;
 
 const PlayerInfoList = ({ teamName, players }: IPlayerList) => {
   return (

--- a/FE/src/components/PlayerListPage/PlayerInfoList/PlayerInfoList.tsx
+++ b/FE/src/components/PlayerListPage/PlayerInfoList/PlayerInfoList.tsx
@@ -1,0 +1,48 @@
+import React from "react";
+import styled from "styled-components";
+import { IPlayerList, IPlayer } from "@/models/playerList";
+
+const Wrapper = styled.table``;
+
+const TeamTitle = styled.div``;
+
+const Table = styled.div``;
+
+const THeader = styled.thead``;
+
+const TBody = styled.tbody``;
+
+const PlayerInfoList = ({ teamName, players }: IPlayerList) => {
+  return (
+    <Wrapper>
+      <TeamTitle>
+        {teamName}
+        {<span>Player</span>}
+      </TeamTitle>
+      <Table>
+        <THeader>
+          <tr>
+            <th>타자</th>
+            <th>타석</th>
+            <th>안타</th>
+            <th>아웃</th>
+            <th>평균</th>
+          </tr>
+        </THeader>
+        <TBody>
+          {players.map(({ name, atBat, hits, outs }: IPlayer) => (
+            <tr key={name + atBat + hits + outs}>
+              <td>{name}</td>
+              <td>{atBat}</td>
+              <td>{hits}</td>
+              <td>{outs}</td>
+              <td>??</td>
+            </tr>
+          ))}
+        </TBody>
+      </Table>
+    </Wrapper>
+  );
+};
+
+export default PlayerInfoList;

--- a/FE/src/components/PlayerListPage/PlayerListPage.tsx
+++ b/FE/src/components/PlayerListPage/PlayerListPage.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+import styled from "styled-components";
+import PlayerInfoList from "@/components/PlayerListPage/PlayerInfoList/PlayerInfoList";
+import { IPlayerList, playerList } from "@/models/playerList";
+
+const Wrapper = styled.div`
+  background-color: #000;
+  height: 100vh;
+  width: 100vw;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+const PlayerListContainer = styled.div`
+  color: #fff;
+  display: flex;
+  justify-content: center;
+  width: 900px;
+  height: 500px;
+  outline: solid 2px #fff;
+`;
+
+const PlayerListPage = () => {
+  return (
+    <Wrapper>
+      <PlayerListContainer>
+        {playerList &&
+          playerList.map(({ teamName, players }: IPlayerList, index: number) => (
+            <PlayerInfoList key={index} teamName={teamName} players={players} />
+          ))}
+      </PlayerListContainer>
+    </Wrapper>
+  );
+};
+
+export default PlayerListPage;

--- a/FE/src/models/playerList.ts
+++ b/FE/src/models/playerList.ts
@@ -1,0 +1,24 @@
+import playerListData from "./playerListData";
+
+interface IPlayerList {
+  teamName: string;
+  players: IPlayer[];
+}
+
+interface IPlayer {
+  name: string;
+  atBat: number;
+  hits: number;
+  outs: number;
+}
+
+const getPlayerList = (playerListInfo: IPlayerList) => {
+  return playerListInfo;
+};
+
+const playerList: IPlayerList[] = [];
+playerListData.forEach((player: IPlayerList, index: number) => {
+  playerList[index] = getPlayerList(player);
+});
+
+export { IPlayerList, IPlayer, playerList };

--- a/FE/src/models/playerListData.ts
+++ b/FE/src/models/playerListData.ts
@@ -1,0 +1,122 @@
+const playerListData = [
+  {
+    teamName: "Captin",
+    players: [
+      {
+        name: "김광진",
+        atBat: 1,
+        hits: 1,
+        outs: 0,
+      },
+      {
+        name: "이동규",
+        atBat: 1,
+        hits: 0,
+        outs: 1,
+      },
+      {
+        name: "김진수",
+        atBat: 1,
+        hits: 0,
+        outs: 1,
+      },
+      {
+        name: "박영권",
+        atBat: 1,
+        hits: 1,
+        outs: 0,
+      },
+      {
+        name: "추신수",
+        atBat: 1,
+        hits: 1,
+        outs: 0,
+      },
+      {
+        name: "이용대",
+        atBat: 1,
+        hits: 0,
+        outs: 1,
+      },
+      {
+        name: "류현진",
+        atBat: 1,
+        hits: 0,
+        outs: 1,
+      },
+      {
+        name: "최동수",
+        atBat: 1,
+        hits: 0,
+        outs: 1,
+      },
+      {
+        name: "한양범",
+        atBat: 1,
+        hits: 1,
+        outs: 0,
+      },
+    ],
+  },
+  {
+    teamName: "Marvel",
+    players: [
+      {
+        name: "김광진",
+        atBat: 1,
+        hits: 1,
+        outs: 0,
+      },
+      {
+        name: "이동규",
+        atBat: 1,
+        hits: 0,
+        outs: 1,
+      },
+      {
+        name: "김진수",
+        atBat: 1,
+        hits: 0,
+        outs: 1,
+      },
+      {
+        name: "박영권",
+        atBat: 1,
+        hits: 1,
+        outs: 0,
+      },
+      {
+        name: "추신수",
+        atBat: 1,
+        hits: 1,
+        outs: 0,
+      },
+      {
+        name: "이용대",
+        atBat: 1,
+        hits: 0,
+        outs: 1,
+      },
+      {
+        name: "류현진",
+        atBat: 1,
+        hits: 0,
+        outs: 1,
+      },
+      {
+        name: "최동수",
+        atBat: 1,
+        hits: 0,
+        outs: 1,
+      },
+      {
+        name: "한양범",
+        atBat: 1,
+        hits: 1,
+        outs: 0,
+      },
+    ],
+  },
+];
+
+export default playerListData;


### PR DESCRIPTION
### 구현한 내용

- 선수 명단 페이지 구성
- 데이터는 mock API 바탕으로 생성함
- 나의 팀(player), 현태 경기중인 플레이어, total 횟수는 데이터 추가 필요

![image](https://user-images.githubusercontent.com/30427711/81562274-82313e00-93cf-11ea-9960-8d88c4a442c0.png)


Close #38 